### PR TITLE
Cambios en la implementación de palabras aleatorias.

### DIFF
--- a/examples/GetRandomWord.js
+++ b/examples/GetRandomWord.js
@@ -7,6 +7,6 @@ const rae = new RAE();
   console.log(`Id de la palabra: ${ random.getId() }`);
   console.log(`Definiciones:\n`);
   random.getDefinitions().forEach(d => {
-    console.log(`\t- (${ d.type }) ${ d.definition }`);
+    console.log(`\t- (${ d.getType() }) ${ d.getDefinition() }`);
   });
 })();

--- a/src/Response/RandomWordResponse.js
+++ b/src/Response/RandomWordResponse.js
@@ -1,4 +1,5 @@
 const Response = require('../Response');
+const Definition = require('./Model/Definition');
 const {IncomingMessage} = require('http');
 
 /**
@@ -10,7 +11,7 @@ const {IncomingMessage} = require('http');
  * @method bool isId()
  */
 class RandomWordResponse extends Response{
-	#definitions;
+	#definitions = [];
 	#header;
 	#id;
 	/**
@@ -22,7 +23,11 @@ class RandomWordResponse extends Response{
 		const body = response.body;
 		if (body.header) this.#header = body.header;
 		if (body.id) this.#id = body.id;
-		if (body.definitions) this.#definitions = body.definitions;
+		if (body.definitions){
+			for (const def of body.definitions){
+				this.#definitions.push(new Definition(def));
+			}
+		}
 	}
 
 	/**
@@ -36,9 +41,9 @@ class RandomWordResponse extends Response{
 	isId(){ return this.#id ? true : false; }
 
 	/**
-	 * @returns {boolean} Sí o no la palabra tiene definición.
+	 * @returns {boolean} Sí o no la palabra tiene definiciones disponibles.
 	 */
-	isDefinition(){ return this.#definitions ? true : false; }
+	areDefinitions(){ return this.#definitions ? true : false; }
 
 	/**
 	 * @returns {string} El encabezado de la palabra.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,6 +31,15 @@ declare module "rae-api" {
 		getHeader(): boolean;
 		getId(): string;
 	}
+	export class RandomWordResponse extends Response {
+		constructor(response: IncomingMessage & {body: {header: string, id: string, definitions: {type?: string, definition?: string}[]}});
+		isHeader(): boolean;
+		isId(): boolean;
+		areDefinitions(): boolean;
+		getHeader(): string;
+		getId(): string;
+		getDefinitions(): Definition[];
+	}
 	export class KeyQueryResponse extends Response {
 		constructor(response: IncomingMessage & {body: string[]});
 		areKeys(): boolean;


### PR DESCRIPTION
## Cambios
- El método de verificación de definiciones de `<RandomWordResponse>` pasó de `isDefinition()` -> `areDefinition()` debido a que una misma palabra puede devolver más de una definición.
- `<RandomWordResponse>.getDefinitions()` ahora devuelve `<Definition>[]` en lugar de un diccionario.
- El ejemplo `examples/GetRandomWord.js` ahora implementa los nuevos métodos de `<Definition>`.

## Implementaciones
- La clase `<RandomWordResponse>` ahora se exporta correctamente desde el archivo `index.d.ts`.

> No te preocupes mano, yo tampoco sé usar muy bien GitHub jajaja.